### PR TITLE
Decode SSL Response message

### DIFF
--- a/src/main/java/com/julienviet/pgclient/codec/decoder/MessageDecoder.java
+++ b/src/main/java/com/julienviet/pgclient/codec/decoder/MessageDecoder.java
@@ -67,9 +67,8 @@ public class MessageDecoder extends ByteToMessageDecoder {
   @Override
   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
     while (true) {
-      if (in.readableBytes() < 5) {
-        byte sslResponse = in.getByte(0);
-        switch (sslResponse) {
+      if (in.readableBytes() == 1) {
+        switch (in.getByte(0)) {
           case SSL_YES: {
             out.add(new SSLResponse(true));
             break;
@@ -79,6 +78,9 @@ public class MessageDecoder extends ByteToMessageDecoder {
             break;
           }
         }
+        break;
+      }
+      if (in.readableBytes() < 5) {
         break;
       }
       int beginIdx = in.readerIndex();

--- a/src/main/java/com/julienviet/pgclient/codec/decoder/MessageDecoder.java
+++ b/src/main/java/com/julienviet/pgclient/codec/decoder/MessageDecoder.java
@@ -41,6 +41,7 @@ import com.julienviet.pgclient.codec.decoder.message.PortalSuspended;
 import com.julienviet.pgclient.codec.decoder.message.ReadyForQuery;
 import com.julienviet.pgclient.codec.decoder.message.Response;
 import com.julienviet.pgclient.codec.decoder.message.RowDescription;
+import com.julienviet.pgclient.codec.decoder.message.SSLResponse;
 import com.julienviet.pgclient.codec.util.Util;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -67,6 +68,17 @@ public class MessageDecoder extends ByteToMessageDecoder {
   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
     while (true) {
       if (in.readableBytes() < 5) {
+        byte sslResponse = in.getByte(0);
+        switch (sslResponse) {
+          case SSL_YES: {
+            out.add(new SSLResponse(true));
+            break;
+          }
+          case SSL_NO: {
+            out.add(new SSLResponse(false));
+            break;
+          }
+        }
         break;
       }
       int beginIdx = in.readerIndex();

--- a/src/main/java/com/julienviet/pgclient/codec/decoder/message/SSLResponse.java
+++ b/src/main/java/com/julienviet/pgclient/codec/decoder/message/SSLResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.julienviet.pgclient.codec.decoder.message;
+
+import com.julienviet.pgclient.codec.Message;
+
+import java.util.Objects;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class SSLResponse implements Message {
+
+  private final boolean ok;
+
+  public SSLResponse(boolean ok) {
+    this.ok = ok;
+  }
+
+  public boolean isOk() {
+    return ok;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SSLResponse that = (SSLResponse) o;
+    return ok == that.ok;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ok);
+  }
+
+
+  @Override
+  public String toString() {
+    return "SSLResponse{" +
+      "ok=" + ok +
+      '}';
+  }
+}

--- a/src/main/java/com/julienviet/pgclient/codec/decoder/message/type/MessageType.java
+++ b/src/main/java/com/julienviet/pgclient/codec/decoder/message/type/MessageType.java
@@ -45,4 +45,6 @@ public class MessageType {
   public static final byte BIND_COMPLETE = '2';
   public static final byte CLOSE_COMPLETE = '3';
   public static final byte FUNCTION_RESULT = 'V';
+  public static final byte SSL_YES = 'S';
+  public static final byte SSL_NO = 'N';
 }


### PR DESCRIPTION
The server then responds with a **single byte** containing **S** or **N**, indicating that it is willing or unwilling to perform SSL, respectively.